### PR TITLE
Initial commit for ChannelCaching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "extends": "airbnb-base" ,
+  "env": {
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+  "rules": {
+    "indent": [2, 2, {"SwitchCase": 1}],
+    "strict": [2, "global"],
+    "no-multiple-empty-lines": 0,
+    "comma-dangle": [2, "never"],
+    "func-names": 0,
+    "one-var": 0,
+    "vars-on-top": 0,
+    "id-length": 0,
+    "no-param-reassign": 0,
+    "new-cap": 0,
+    "consistent-return": 0,
+    "space-before-function-paren": [2, { "anonymous": "never", "named": "never" }],
+    "max-len": 0,
+    "generator-star-spacing": ["error", {"before": true, "after": false}],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": false, "peerDependencies": false}]
+  },
+
+  "ecmaFeatures": {
+    "modules": false
+  },
+
+  "globals": {
+    "require": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+#Editors
+.vscode

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Enables cached channel configurations for communicating with AppDirect.",
   "main": "/src/index.js",
   "scripts": {
+    "lint": "eslint src test",
     "coverage": "istanbul cover _mocha -- -R spec",
     "test": "mocha test -u bdd -R spec --ui bdd --recursive"
   },
@@ -17,15 +18,24 @@
     "configuration",
     "cache"
   ],
+  "homepage": "https://github.com/kaligan/ad-node-channel-configuration#readme",
   "author": {
     "name": "AppDirect",
     "url": "https://www.appdirect.com"
   },
-  "license": "ISC",
+  "contributors": [
+    {
+      "name": "Matt Nicholson",
+      "email": "matt.nicholson@appdirect.com"
+    },
+    {
+      "name": "Rahul Bir",
+      "email": "rahul.bir@appdirect.com"
+    }
+  ],
   "bugs": {
     "url": "https://github.com/kaligan/ad-node-channel-configuration/issues"
   },
-  "homepage": "https://github.com/kaligan/ad-node-channel-configuration#readme",
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.1.1",
@@ -36,5 +46,8 @@
   },
   "dependencies": {
     "lodash": "^4.14.0"
+  },
+  "engines": {
+    "node": ">=4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "ad-node-channel-configuration",
+  "version": "0.0.1",
+  "description": "Enables cached channel configurations for communicating with AppDirect.",
+  "main": "/src/index.js",
+  "scripts": {
+    "coverage": "istanbul cover _mocha -- -R spec",
+    "test": "mocha test -u bdd -R spec --ui bdd --recursive"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kaligan/ad-node-channel-configuration.git"
+  },
+  "keywords": [
+    "appdirect",
+    "channel",
+    "configuration",
+    "cache"
+  ],
+  "author": {
+    "name": "AppDirect",
+    "url": "https://www.appdirect.com"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kaligan/ad-node-channel-configuration/issues"
+  },
+  "homepage": "https://github.com/kaligan/ad-node-channel-configuration#readme",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^3.1.1",
+    "eslint-config-airbnb-base": "^5.0.0",
+    "eslint-plugin-import": "^1.12.0",
+    "istanbul": "^0.4.4",
+    "mocha": "^2.5.3"
+  },
+  "dependencies": {
+    "lodash": "^4.14.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,92 @@
+'use strict';
+const _ = require('lodash');
+const url = require('url');
+
+class ChannelConfigurations {
+  constructor(configurations, options) {
+    this.logger = _.get(options, 'logger', console);
+
+    this.configurations = new Map();
+    if (configurations) {
+      this.setConfigurations(configurations);
+    }
+  }
+
+  toString() {
+    const json = {};
+    this.configurations.forEach((value, key) => {
+      json[key] = value;
+    });
+
+    return JSON.stringify(json);
+  }
+
+  getConfigurations() {
+    return this.configurations;
+  }
+
+  setConfigurations(configurations) {
+    this.configurations.clear();
+
+    if (configurations instanceof Map) {
+      this.configurations = new Map(configurations);
+    } else if (configurations instanceof Array) {
+      this.configurations.clear();
+      for (const c of configurations) {
+        this.add(c);
+      }
+    } else if (configurations instanceof Object && !_.isEmpty(configurations)) {
+      _.forOwn(configurations, (value, key) => {
+        value.name = key;
+        this.add(value);
+      });
+    } else {
+      throw new Error(`Unsupported type for configuration field:${typeof configurations}.  Configurations must be of the following types: Map<name, configuration>, List<configuration>, or Object<name, configuration>`);
+    }
+
+    return this.configurations;
+  }
+
+  add(configuration) {
+    if (_.isEmpty(configuration)) {
+      throw new Error('Couldn\'t add empty configuration');
+    }
+
+    if (!configuration.name) {
+      throw new Error(`name is a required field: ${JSON.stringify(configuration)}`);
+    }
+
+    if (!configuration.partner) {
+      throw new Error(`partner is a required field: ${JSON.stringify(configuration)}`);
+    }
+
+    if (!configuration.baseUrl) {
+      throw new Error(`baseUrl is a required field: ${JSON.stringify(configuration)}`);
+    }
+    const parsedBaseUrl = url.parse(configuration.baseUrl);
+    if (!parsedBaseUrl.protocol || !parsedBaseUrl.host || !parsedBaseUrl.path) {
+      throw new Error(`Invalid baseUrl: ${configuration.baseurl}, must be a properly formatted url according to the node URL object.`);
+    }
+
+    this.configurations.set(configuration.name.toLowerCase(), configuration);
+  }
+
+  get(name) {
+    if (!name) {
+      throw new Error('name is a requied argument');
+    }
+
+    const configuration = this.configurations.get(name.toLowerCase());
+    if (!configuration) {
+      throw new Error(`Configuration with the name: ${name} doesn't exist.  Valid names are ${this.configurations.keys().toString()}`);
+    }
+
+    return configuration;
+  }
+
+  delete(name) {
+    return this.configurations.delete(name);
+  }
+}
+
+module.exports = ChannelConfigurations;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,243 @@
+const ChannelConfigurations = require('../src/index');
+const chai = require('chai');
+const assert = require('assert');
+
+describe('AppDirect ChannelConfiguration Tests', () => {
+  chai.should();
+
+  const testConfigurations = new Map()
+    .set('appdirect', {
+      name: 'appdirect',
+      partner: 'APPDIRECT',
+      baseUrl: 'https://www.appdirect.com'
+    })
+    .set('test', {
+      name: 'test',
+      partner: 'APPDIRECT',
+      baseUrl: 'https://test.appdirect.com'
+    });
+
+  describe('constructor', () => {
+    it('Should work for a null constructor', () => {
+      const configurations = new ChannelConfigurations();
+      assert.equal(true, configurations instanceof ChannelConfigurations);
+    });
+
+    it('Should work for an undefined constructor', () => {
+      const configurations = new ChannelConfigurations(undefined);
+      assert.equal(true, configurations instanceof ChannelConfigurations);
+    });
+
+    it('Should create a new ChannelConfigurationCache with valid Array constructor.', () => {
+      const configurations = new ChannelConfigurations([{
+        name: 'test',
+        partner: 'test',
+        baseUrl: 'http://www.test.com'
+      }]);
+
+      assert.equal(true, configurations instanceof ChannelConfigurations);
+    });
+
+    it('Should create a new ChannelConfigurationCache with valid Map constructor.', (done) => {
+      const map = new Map();
+      map.set('test', {
+        name: 'test',
+        partner: 'test',
+        baseUrl: 'http://www.test.com'
+      });
+
+      const configurations = new ChannelConfigurations(map);
+      assert.equal(true, configurations instanceof ChannelConfigurations);
+      done();
+    });
+
+    it('Should create a new ChannelConfigurationCache with valid Object constructor.', (done) => {
+      const configurations = new ChannelConfigurations({
+        test: {
+          name: 'test',
+          partner: 'test',
+          baseUrl: 'http://www.test.com'
+        }
+      });
+      assert.equal(true, configurations instanceof ChannelConfigurations);
+      done();
+    });
+
+    it('Should throw an error when creating a new ChannelConfigurationCache with an invalid constructor type.', (done) => {
+      try {
+        const temp = new ChannelConfigurations(new Date());
+        done(`Didn't throw expected exception: ${temp.toString()}`);
+      } catch (e) {
+        assert.equal(true, e.message.indexOf('Unsupported type for configuration field') >= 0, `Error ${e.message} doesn't contain the text 'Unsupported type for configuration field'`);
+        done();
+      }
+    });
+  });
+
+  describe('method: toString()', () => {
+    it('Should return a string representing all the channel configurations that are cached', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      const text = channelConfigs.toString();
+      text.should.be.a('string');
+      done();
+    });
+  });
+
+  describe('method: getConfigurations()', () => {
+    it('Should return the cached map of configurations', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      const configurations = channelConfigs.getConfigurations();
+
+      configurations.should.be.a('map');
+
+      const test = configurations.get('test');
+      test.name.should.equal(testConfigurations.get('test').name);
+      test.partner.should.equal(testConfigurations.get('test').partner);
+      test.baseUrl.should.equal(testConfigurations.get('test').baseUrl);
+
+      const appdirect = configurations.get('appdirect');
+      appdirect.name.should.equal(testConfigurations.get('appdirect').name);
+      appdirect.partner.should.equal(testConfigurations.get('appdirect').partner);
+      appdirect.baseUrl.should.equal(testConfigurations.get('appdirect').baseUrl);
+      done();
+    });
+  });
+
+  describe('method: add()', () => {
+    it('Should add a new test configuration', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      channelConfigs.add({
+        name: 'test_add',
+        partner: 'test_partner',
+        baseUrl: 'https://test.appdirect.com'
+      });
+
+      const configurations = channelConfigs.getConfigurations();
+      configurations.should.be.a('map');
+
+      const addedConfiguration = configurations.get('test_add');
+      addedConfiguration.should.be.a('object');
+      addedConfiguration.name.should.equal('test_add');
+      addedConfiguration.partner.should.equal('test_partner');
+      addedConfiguration.baseUrl.should.equal('https://test.appdirect.com');
+      done();
+    });
+
+    it('Should throw an error for an empty configuration', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.add({});
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+
+    it('Should throw an error for a configuration missing the name property', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.add({
+          partner: 'test_partner',
+          baseUrl: 'https://test.appdirect.com'
+        });
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+
+    it('Should throw an error for a configuration missing the partner property', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.add({
+          name: 'test_add',
+          baseUrl: 'https://test.appdirect.com'
+        });
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+
+    it('Should throw an error for a configuration missing the baseUrl property', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.add({
+          name: 'test_add',
+          partner: 'test_partner'
+        });
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+
+
+    it('Should throw an error for a configuration with an invalid baseUrl property', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.add({
+          name: 'test_add',
+          partner: 'test_partner',
+          baseUrl: 'skdfljs'
+        });
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+  });
+
+  describe('method: get(name)', () => {
+    it('Should get a valid configuration from the cached configurations', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      const appdirectConfig = channelConfigs.get('appdirect');
+
+      appdirectConfig.should.be.a('object');
+      appdirectConfig.name.should.equal('appdirect');
+      appdirectConfig.partner.should.equal('APPDIRECT');
+      appdirectConfig.baseUrl.should.equal('https://www.appdirect.com');
+      done();
+    });
+
+    it('Should throw an error if the configuration doesn\'t exit', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.get('invalidName');
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+
+    it('Should throw an error if the name parameter isn\'t provided.', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      try {
+        channelConfigs.get();
+        done('Should have thrown an error');
+      } catch (e) {
+        done();
+      }
+    });
+  });
+
+  describe('method: delete(name)', () => {
+    it('Should return true when deleting a chached configuration that exist.', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      const response = channelConfigs.delete('appdirect');
+
+      response.should.be.a('boolean');
+      response.should.equal(true);
+      done();
+    });
+
+    it('Should return false when deleting a chached configuration that doesn\'t exits.', (done) => {
+      const channelConfigs = new ChannelConfigurations(testConfigurations);
+      const response = channelConfigs.delete('invalidName');
+
+      response.should.be.a('boolean');
+      response.should.equal(false);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
ChannelCaching is to be used when proxying to AppDirect channels.  It
caches the channels used and allows lookups by channel name.